### PR TITLE
change making sim dfs only from GSC

### DIFF
--- a/geneplexus/geneplexus.py
+++ b/geneplexus/geneplexus.py
@@ -387,7 +387,7 @@ class GenePlexus:
             **PosGenes** (positive genes for this DO term).
 
         """
-        self.df_sim_GO, self.df_sim_Dis, self.weights_GO, self.weights_Dis = _geneplexus._make_sim_dfs(
+        self.df_sim, self.weights_dict = _geneplexus._make_sim_dfs(
             self.file_loc,
             self.mdl_weights,
             self.sp_tst,
@@ -395,7 +395,7 @@ class GenePlexus:
             self.net_type,
             self.features,
         )
-        return self.df_sim_GO, self.df_sim_Dis, self.weights_GO, self.weights_Dis
+        return self.df_sim, self.weights_dict
 
     def make_small_edgelist(self, num_nodes: int = 50):
         """Make a subgraph induced by the top predicted genes.

--- a/geneplexus/util.py
+++ b/geneplexus/util.py
@@ -234,7 +234,7 @@ def load_gsc(
 def load_pretrained_weights(
     file_loc: str,
     species: config.SPECIES_TYPE,
-    target_set: config.GSC_TYPE,
+    gsc: config.GSC_TYPE,
     net_type: config.NET_TYPE,
     features: config.FEATURE_TYPE,
 ) -> config.PRETRAINED_DATA_TYPE:
@@ -243,12 +243,12 @@ def load_pretrained_weights(
     Args:
         file_loc: Location of data files.
         species: The species of the gene set collection.
-        target_set: Target gene set collection.
+        gsc: The gene set collection.
         net_type: Network used.
         features: Type of features used.
 
     """
-    file_name = f"PreTrainedWeights__{species}__{target_set}__{net_type}__{features}.json"
+    file_name = f"PreTrainedWeights__{species}__{gsc}__{net_type}__{features}.json"
     return _load_json_file(file_loc, file_name)
 
 
@@ -334,7 +334,7 @@ def load_gene_features(
 def load_correction_order(
     file_loc: str,
     species: config.SPECIES_TYPE,
-    target_set: config.GSC_TYPE,
+    gsc: config.GSC_TYPE,
     net_type: config.NET_TYPE,
 ) -> np.ndarray:
     """Load correction matrix order.
@@ -342,11 +342,11 @@ def load_correction_order(
     Args:
         file_loc: Location of data files.
         species: The species of files.
-        target_set: Target gene set collection.
+        gsc: The gene set collection.
         net_type: Network used.
 
     """
-    file_name = f"CorrectionMatrixOrder__{species}__{target_set}__{net_type}.txt"
+    file_name = f"CorrectionMatrixOrder__{species}__{gsc}__{net_type}.txt"
     return _load_np_file(file_loc, file_name, load_method="txt")
 
 


### PR DESCRIPTION
Previously, a model weight similarity data frame was made separately for GO and DisGeNet, now it will be created from only the GCS which the model was trained, but that GSC can contain terms from many different sources.