### PR TITLE
fixed file name issue in #404

### DIFF
--- a/geneplexus/_geneplexus.py
+++ b/geneplexus/_geneplexus.py
@@ -377,12 +377,11 @@ def _alter_validation_df(df_convert_out, pos_genes_for_model, net_type):
 
 def _save_class(gp, output_dir, save_type, zip_output, overwrite):
     output_dir = util.suffix_dir(output_dir, overwrite=overwrite)
-    if zip_output:
-        zip_outpath = util.suffix_zip(f"{output_dir}.zip", overwrite=overwrite)
     util._save_results(gp, output_dir, save_type)
     # Optionally zip the result directory
     if zip_output:
         outpath = pathlib.Path(output_dir)
+        zip_outpath = f"{outpath}.zip"
         logger.info("Zipping output files")
         shutil.make_archive(zip_outpath[:-4], "zip", outpath.parent, outpath.name)
         shutil.rmtree(output_dir)

--- a/geneplexus/util.py
+++ b/geneplexus/util.py
@@ -551,7 +551,7 @@ def suffix_dir(path, idx=0, overwrite=False):
     if path == None:
         path = str(pystow.join("geneplexus_outputs/results"))
     new_path = normexpand(f"{path}_{idx}" if idx > 0 else path)
-    if os.listdir(new_path):
+    if os.listdir(new_path) or osp.isfile(f"{new_path}.zip"):
         if overwrite:
             logger.warning(f"Output directory exits {path}, overwriting.")
             shutil.rmtree(new_path)
@@ -560,20 +560,6 @@ def suffix_dir(path, idx=0, overwrite=False):
             new_path = suffix_dir(path, idx=idx + 1)
     elif path != new_path:
         logger.warning(f"Output directory exists {path}, redirecting to {new_path}")
-    return new_path
-
-
-def suffix_zip(path, idx=0, overwrite=False):
-    """Add int suffix to file name if file existed."""
-    new_path = f"_{idx}".join(osp.splitext(path)) if idx > 0 else path
-    if osp.isfile(new_path):
-        if overwrite:
-            logger.warning(f"Output zip file exits {path}, overwriting.")
-            os.remove(new_path)
-        else:
-            new_path = suffix_zip(path, idx=idx + 1)
-    elif path != new_path:
-        logger.warning(f"Output zip file exists {path}, redirecting to {new_path}")
     return new_path
 
 


### PR DESCRIPTION
this fixed how filenames are generated when no overwriting is selected. The new way is it look for a folders or zip files with the name and then will incriminate by one if either is already existing.